### PR TITLE
feat: create routes for API

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,6 @@
+PORT=xx
+DB_HOST=127.xx.xx.xx
+DB_NAME=dbname
+DB_USER=dbuser
+DB_PASSWORD=dbpassword
+BASE_URL=http://localhost:

--- a/server/controllers/lift-records.ts
+++ b/server/controllers/lift-records.ts
@@ -1,0 +1,33 @@
+import { RequestHandler } from "express";
+
+export const getUserRecords: RequestHandler = (req, res) => {
+  // Fetch user records from the database
+  const userId = req.params.userId;
+  res.status(200).send(userId);
+};
+
+export const getRecordById: RequestHandler = (req, res) => {
+  // Gets a single record based on id
+  const { userId, liftId } = req.params;
+  res.status(200).send(`${userId}, ${liftId} retrieved`);
+};
+
+export const addNewRecord: RequestHandler = (req, res) => {
+  // Add a new record to the database
+  // This will also need to accept a body for the new record
+  const userId = req.params.userId;
+  res.status(200).send(userId);
+};
+
+export const updateRecord: RequestHandler = (req, res) => {
+  // Updates a record in the database
+  // This will also need to accept a body for the updated record
+  const { userId, liftId } = req.params;
+  res.status(200).send(`${userId}, ${liftId} updated`);
+};
+
+export const deleteRecord: RequestHandler = (req, res) => {
+  // Deletes a record from the database
+  const { userId, liftId } = req.params;
+  res.status(200).send(`${userId}, ${liftId} deleted`);
+};

--- a/server/controllers/lift-targets.ts
+++ b/server/controllers/lift-targets.ts
@@ -1,0 +1,17 @@
+import { RequestHandler } from "express";
+
+export const getTargetById: RequestHandler = (req, res) => {
+  // Fetch user records from the database
+  const { userId, liftId } = req.params;
+  res.status(200).send(`${userId}, ${liftId}`);
+};
+
+export const addNewTarget: RequestHandler = (req, res) => {
+  const { userId, liftId } = req.params;
+  res.status(200).send(`${userId}, ${liftId}`);
+};
+
+export const updateTarget: RequestHandler = (req, res) => {
+  const targetId = req.params;
+  res.status(200).send(targetId);
+};

--- a/server/controllers/lifts.ts
+++ b/server/controllers/lifts.ts
@@ -1,9 +1,9 @@
 import { RequestHandler } from "express";
 
-export const getAllLifts: RequestHandler = (req, res) => {
+export const getAllLifts: RequestHandler = (_req, res) => {
   res.status(200).send("lifts");
 };
 
-export const addNewLift: RequestHandler = (req, res) => {
+export const addNewLift: RequestHandler = (_req, res) => {
   res.status(200).send("Add a new lift");
 };

--- a/server/controllers/lifts.ts
+++ b/server/controllers/lifts.ts
@@ -1,0 +1,9 @@
+import { RequestHandler } from "express";
+
+export const getAllLifts: RequestHandler = (req, res) => {
+  res.status(200).send("lifts");
+};
+
+export const addNewLift: RequestHandler = (req, res) => {
+  res.status(200).send("Add a new lift");
+};

--- a/server/index.ts
+++ b/server/index.ts
@@ -6,15 +6,14 @@ import { liftRoutes } from "./routes/lifts.js";
 import { liftRecordsRoutes } from "./routes/lift-records.js";
 import { liftTargetRoutes } from "./routes/lift-targets.js";
 import { userRoutes } from "./routes/users.js";
-// import knexConfig from "./knexfile.js";
 
 const { parsed } = configDotenv();
+const PORT = parsed?.PORT || 8080;
+
 const app = express();
 
 app.use(express.json());
 app.use(cors());
-// const db = knexConfig;
-const PORT = parsed?.PORT || 8080;
 
 app.get("/", (_req, res) => {
   res.send("Hello World");

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,6 +2,10 @@ import express from "express";
 import cors from "cors";
 
 import { configDotenv } from "dotenv";
+import { liftRoutes } from "./routes/lifts.js";
+import { liftRecordsRoutes } from "./routes/lift-records.js";
+import { liftTargetRoutes } from "./routes/lift-targets.js";
+import { userRoutes } from "./routes/users.js";
 // import knexConfig from "./knexfile.js";
 
 const { parsed } = configDotenv();
@@ -15,6 +19,11 @@ const PORT = parsed?.PORT || 8080;
 app.get("/", (_req, res) => {
   res.send("Hello World");
 });
+
+app.use("/lifts", liftRoutes);
+app.use("/lift-records", liftRecordsRoutes);
+app.use("/lift-targets", liftTargetRoutes);
+app.use("/users", userRoutes);
 
 app.listen(PORT, () => {
   console.log(`running at ${process.env.BASE_URL}${PORT}`);

--- a/server/routes/lift-records.ts
+++ b/server/routes/lift-records.ts
@@ -1,9 +1,27 @@
 import express from "express";
+import {
+  addNewRecord,
+  deleteRecord,
+  getRecordById,
+  getUserRecords,
+  updateRecord,
+} from "../controllers/lift-records.js";
 
 const router = express.Router();
 
-router.get("/", (_req, res) => {
-  res.send("Lift records page");
-});
+/**
+ * I need to get lift records for a user
+ * I don't need to get all lift records
+ * I need to add a new lift record
+ * I need to update an existing lift record
+ * I need to delete a lift record
+ */
+
+router.route("/:userId").get(getUserRecords).post(addNewRecord);
+router
+  .route("/:userId/:liftId")
+  .get(getRecordById)
+  .put(updateRecord)
+  .delete(deleteRecord);
 
 export const liftRecordsRoutes = router;

--- a/server/routes/lift-records.ts
+++ b/server/routes/lift-records.ts
@@ -17,9 +17,9 @@ const router = express.Router();
  * I need to delete a lift record
  */
 
-router.route("/:userId").get(getUserRecords).post(addNewRecord);
+router.route("/user/:userId").get(getUserRecords).post(addNewRecord);
 router
-  .route("/:userId/:liftId")
+  .route("/user/:userId/lift/:liftId")
   .get(getRecordById)
   .put(updateRecord)
   .delete(deleteRecord);

--- a/server/routes/lift-records.ts
+++ b/server/routes/lift-records.ts
@@ -1,0 +1,9 @@
+import express from "express";
+
+const router = express.Router();
+
+router.get("/", (_req, res) => {
+  res.send("Lift records page");
+});
+
+export const liftRecordsRoutes = router;

--- a/server/routes/lift-targets.ts
+++ b/server/routes/lift-targets.ts
@@ -1,9 +1,22 @@
 import express from "express";
+import {
+  addNewTarget,
+  getTargetById,
+  updateTarget,
+} from "../controllers/lift-targets.js";
 
 const router = express.Router();
 
-router.get("/", (_req, res) => {
-  res.send("Lift target page");
-});
+/**
+ * I need to be able to get a single lift target
+ * I need to be able to update a single lift
+ * I need to be able to add a lift target
+ */
 
+router
+  .route("/user/:userId/lift/:liftId")
+  .get(getTargetById)
+  .post(addNewTarget);
+
+router.put("/target/:targetId", updateTarget);
 export const liftTargetRoutes = router;

--- a/server/routes/lift-targets.ts
+++ b/server/routes/lift-targets.ts
@@ -1,0 +1,9 @@
+import express from "express";
+
+const router = express.Router();
+
+router.get("/", (_req, res) => {
+  res.send("Lift target page");
+});
+
+export const liftTargetRoutes = router;

--- a/server/routes/lifts.ts
+++ b/server/routes/lifts.ts
@@ -1,9 +1,13 @@
 import express from "express";
+import { addNewLift, getAllLifts } from "../controllers/lifts.js";
 
 const router = express.Router();
 
-router.get("/", (_req, res) => {
-  res.send("Lift page");
-});
+/**
+ * For this we need to get all the lifts
+ * We need to be able to add a new one
+ */
+
+router.route("/").get(getAllLifts).post(addNewLift);
 
 export const liftRoutes = router;

--- a/server/routes/lifts.ts
+++ b/server/routes/lifts.ts
@@ -1,0 +1,9 @@
+import express from "express";
+
+const router = express.Router();
+
+router.get("/", (_req, res) => {
+  res.send("Lift page");
+});
+
+export const liftRoutes = router;

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -1,0 +1,9 @@
+import express from "express";
+
+const router = express.Router();
+
+router.get("/", (_req, res) => {
+  res.send("User page");
+});
+
+export const userRoutes = router;


### PR DESCRIPTION
# What does this PR do?

I have built in the routes as I need them for the front end. There's potential ones I have missed, but it's a good starting point to get the frontend churning. 

Tried to build in a clear hierarchy into the routes to help with understanding the different `id`s required at different points. Especially useful for `lift-targets`. 

Throughout this project I have continually gone back and forth in my head around `lift-targets` or `targets` with `lifts` being inferred for what the app is. The thing that keeps me in the `lift-targets` position, especially now for the API routes, sits in the fact I may want to add future `records` or `targets` which may sit out with a `lift`, and the extra wording seems chill right now. I would rather add these wee bits now, which add explicit naming for stuff, rather than update everything later. 

I have done an initial outlining of controllers which helped me work through what routes I needed, and I've left a range of comments around to help with my next PR of interacting with the database and building the controllers. Should help with documentation on decision making.
