### PR TITLE
feat: add request files to connect with API

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,10 +16,12 @@
     "@mui/material": "^7.0.2",
     "@nivo/bar": "^0.88.0",
     "@tanstack/react-router": "^1.116.0",
+    "axios": "^1.9.0",
     "dayjs": "^1.11.13",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "vitest": "^3.1.2"
+    "vitest": "^3.1.2",
+    "zod": "^3.24.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.1",

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@tanstack/react-router':
         specifier: ^1.116.0
         version: 1.116.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      axios:
+        specifier: ^1.9.0
+        version: 1.9.0
       dayjs:
         specifier: ^1.11.13
         version: 1.11.13
@@ -38,6 +41,9 @@ importers:
       vitest:
         specifier: ^3.1.2
         version: 3.1.2(tsx@4.19.3)
+      zod:
+        specifier: ^3.24.3
+        version: 3.24.3
     devDependencies:
       '@eslint/js':
         specifier: ^9.25.1
@@ -994,6 +1000,12 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axios@1.9.0:
+    resolution: {integrity: sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==}
+
   babel-dead-code-elimination@1.0.10:
     resolution: {integrity: sha512-DV5bdJZTzZ0zn0DC24v3jD7Mnidh6xhKa4GfKCbq3sfW8kaWhDdZjP3i81geA8T33tdYqWKw4D3fVv0CwEgKVA==}
 
@@ -1026,6 +1038,10 @@ packages:
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -1060,6 +1076,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -1155,6 +1175,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   diff@7.0.0:
     resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
     engines: {node: '>=0.3.1'}
@@ -1162,14 +1186,34 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   electron-to-chromium@1.5.140:
     resolution: {integrity: sha512-o82Rj+ONp4Ip7Cl1r7lrqx/pXhbp/lh9DpKcMNscFJdh8ebyRofnc7Sh01B4jx403RI0oqTBvlZ7OBIZLMr2+Q==}
 
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.6.0:
     resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.25.2:
     resolution: {integrity: sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==}
@@ -1290,6 +1334,19 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  follow-redirects@1.15.9:
+    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.2:
+    resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
+    engines: {node: '>= 6'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1301,6 +1358,14 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-tsconfig@4.10.0:
     resolution: {integrity: sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==}
@@ -1330,12 +1395,24 @@ packages:
     peerDependencies:
       csstype: ^3.0.10
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -1451,6 +1528,10 @@ packages:
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -1458,6 +1539,14 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -1556,6 +1645,9 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2840,6 +2932,16 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  asynckit@0.4.0: {}
+
+  axios@1.9.0:
+    dependencies:
+      follow-redirects: 1.15.9
+      form-data: 4.0.2
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   babel-dead-code-elimination@1.0.10:
     dependencies:
       '@babel/core': 7.26.10
@@ -2881,6 +2983,11 @@ snapshots:
 
   cac@6.7.14: {}
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001715: {}
@@ -2919,6 +3026,10 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
 
   concat-map@0.0.1: {}
 
@@ -3007,6 +3118,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  delayed-stream@1.0.0: {}
+
   diff@7.0.0: {}
 
   dom-helpers@5.2.1:
@@ -3014,13 +3127,34 @@ snapshots:
       '@babel/runtime': 7.27.0
       csstype: 3.1.3
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   electron-to-chromium@1.5.140: {}
 
   error-ex@1.3.2:
     dependencies:
       is-arrayish: 0.2.1
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.6.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   esbuild@0.25.2:
     optionalDependencies:
@@ -3179,12 +3313,39 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  follow-redirects@1.15.9: {}
+
+  form-data@4.0.2:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      mime-types: 2.1.35
+
   fsevents@2.3.3:
     optional: true
 
   function-bind@1.1.2: {}
 
   gensync@1.0.0-beta.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-tsconfig@4.10.0:
     dependencies:
@@ -3208,9 +3369,17 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
+  gopd@1.2.0: {}
+
   graphemer@1.4.0: {}
 
   has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
 
   hasown@2.0.2:
     dependencies:
@@ -3304,12 +3473,20 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  math-intrinsics@1.1.0: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   minimatch@3.1.2:
     dependencies:
@@ -3392,6 +3569,8 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
 

--- a/client/src/pages/Home/Home.tsx
+++ b/client/src/pages/Home/Home.tsx
@@ -3,18 +3,8 @@ import Header from "./components/Header";
 
 import { LiftsSection } from "./components/LiftsSection";
 import Progress from "./components/Progress/Progress";
-import { useEffect } from "react";
-import { getAllLifts } from "../../requests/lifts";
 
 export const Home = () => {
-  useEffect(() => {
-    const fetchLifts = async () => {
-      const response = await getAllLifts();
-      console.log(response);
-      return response;
-    };
-    fetchLifts();
-  }, []);
   return (
     <main
       style={{

--- a/client/src/pages/Home/Home.tsx
+++ b/client/src/pages/Home/Home.tsx
@@ -3,8 +3,18 @@ import Header from "./components/Header";
 
 import { LiftsSection } from "./components/LiftsSection";
 import Progress from "./components/Progress/Progress";
+import { useEffect } from "react";
+import { getAllLifts } from "../../requests/lifts";
 
 export const Home = () => {
+  useEffect(() => {
+    const fetchLifts = async () => {
+      const response = await getAllLifts();
+      console.log(response);
+      return response;
+    };
+    fetchLifts();
+  }, []);
   return (
     <main
       style={{

--- a/client/src/requests/liftRecords.ts
+++ b/client/src/requests/liftRecords.ts
@@ -1,0 +1,100 @@
+import axios from "axios";
+import { apiUrl, errorResponse } from "./utils";
+import { z } from "zod";
+import { LiftRecord, LiftRecordShape as LiftRecordShape } from "../types/lifts";
+import {
+  InsertSuccess,
+  InsertSuccessResponse,
+  Result,
+  UpdateReponse,
+  UpdateSuccessResponse,
+} from "../types/request";
+import { userSchema } from "../types/users";
+
+export const getUserLiftRecords = async (
+  userId: string
+): Result<LiftRecord[]> => {
+  try {
+    userSchema.pick({ id: true }).parse(userId);
+    const { data } = await axios.get(`${apiUrl}/lift-records/user/${userId}`);
+    LiftRecordShape.array().parse(data);
+    return data;
+  } catch (error) {
+    return errorResponse(error);
+  }
+};
+
+export const getLiftRecordById = async (
+  recordId: string
+): Result<LiftRecord> => {
+  try {
+    z.string().uuid().parse(recordId);
+    const { data } = await axios.get(`${apiUrl}/lift-records/${recordId}`);
+    LiftRecordShape.parse(data);
+    return data;
+  } catch (error) {
+    return errorResponse(error);
+  }
+};
+
+export const addNewLiftRecord = async (
+  userId: string,
+  liftId: string,
+  record: LiftRecord
+): Result<InsertSuccess> => {
+  try {
+    userSchema.pick({ id: true }).parse(userId);
+    z.string().uuid().parse(liftId);
+
+    LiftRecordShape.parse(record);
+
+    const { data } = await axios.post(
+      `${apiUrl}/lift-records/user/${userId}/lift/${liftId}`,
+      record
+    );
+
+    InsertSuccessResponse.parse(data);
+    return data;
+  } catch (error) {
+    return errorResponse(error);
+  }
+};
+
+export const updateLiftRecord = async (
+  recordId: string,
+  updatedRecord: Partial<LiftRecord>
+): Result<UpdateReponse<LiftRecord>> => {
+  try {
+    z.string().uuid().parse(recordId);
+
+    const partialLiftRecord = LiftRecordShape.partial();
+    partialLiftRecord.parse(updatedRecord);
+
+    const { data } = await axios.put(
+      `${apiUrl}/lift-records/record/${recordId}`,
+      updatedRecord
+    );
+
+    UpdateSuccessResponse.parse(data);
+
+    return data;
+  } catch (error) {
+    return errorResponse(error);
+  }
+};
+
+export const deleteLiftRecord = async (
+  recordId: string
+): Result<{ message: string; id: string }> => {
+  try {
+    z.string().uuid().parse(recordId);
+    const { data } = await axios.delete(
+      `${apiUrl}/lift-records/record/${recordId}`
+    );
+    z.object({ message: z.string(), id: z.string() }).parse(data);
+
+    return data;
+  } catch (error) {
+    return errorResponse(error);
+  }
+};

--- a/client/src/requests/liftTargets.ts
+++ b/client/src/requests/liftTargets.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+import { userSchema } from "../types/users";
+import axios from "axios";
+import { apiUrl, errorResponse } from "./utils";
+import {
+  InsertSuccess,
+  InsertSuccessResponse,
+  Result,
+  UpdateReponse,
+  UpdateSuccessResponse,
+} from "../types/request";
+import { LiftTargetBase, LiftTargetShape } from "../types/lifts";
+
+export const getTargetById = async (
+  userId: string,
+  liftId: string
+): Result<LiftTargetBase> => {
+  try {
+    userSchema.pick({ id: true }).parse(userId);
+    z.string().uuid().parse(liftId);
+
+    const { data } = await axios.get(
+      `${apiUrl}/lift-targets/user/${userId}/lift${liftId}`
+    );
+
+    LiftTargetShape.parse(data);
+
+    return data;
+  } catch (error) {
+    return errorResponse(error);
+  }
+};
+
+export const addNewTarget = async (
+  userId: string,
+  liftId: string,
+  newTarget: LiftTargetBase
+): Result<InsertSuccess> => {
+  try {
+    userSchema.pick({ id: true }).parse(userId);
+    z.string().uuid().parse(liftId);
+    LiftTargetShape.parse(newTarget);
+
+    const { data } = await axios.post(
+      `${apiUrl}/lift-targets/user/${userId}/lift/${liftId}`,
+      newTarget
+    );
+
+    InsertSuccessResponse.parse(data);
+
+    return data;
+  } catch (error) {
+    return errorResponse(error);
+  }
+};
+
+export const updateTarget = async (
+  targetId: string,
+  updatedTarget: LiftTargetBase
+): Result<UpdateReponse<LiftTargetBase>> => {
+  try {
+    z.string().uuid().parse(targetId);
+    const partialTargetShape = LiftTargetShape.partial();
+    partialTargetShape.parse(updatedTarget);
+
+    const { data } = await axios.put(
+      `${apiUrl}/lift-targets/target/${targetId}`,
+      updatedTarget
+    );
+    UpdateSuccessResponse.parse(data);
+    return data;
+  } catch (error) {
+    return errorResponse(error);
+  }
+};

--- a/client/src/requests/lifts.ts
+++ b/client/src/requests/lifts.ts
@@ -1,13 +1,11 @@
 import axios from "axios";
 import { Lift, liftSchema } from "../types/lifts";
-import { z } from "zod";
-
-const apiUrl: string = import.meta.env.VITE_API_URL;
-
-type ErrorMessage = {
-  type: "zod error" | "API error" | "unknown error";
-  message: string;
-};
+import {
+  ErrorMessage,
+  SuccessfulInsertResponse,
+  successfulInsertResponseSchema,
+} from "../types/request";
+import { apiUrl, errorResponse } from "./utils";
 
 export const getAllLifts = async (): Promise<Lift[] | ErrorMessage> => {
   try {
@@ -15,12 +13,19 @@ export const getAllLifts = async (): Promise<Lift[] | ErrorMessage> => {
     liftSchema.array().parse(data);
     return data;
   } catch (error) {
-    if (error instanceof z.ZodError) {
-      return { type: "zod error", message: error.message };
-    }
-    if (error instanceof Error) {
-      return { type: "API error", message: error.message };
-    }
-    return { type: "unknown error", message: "An unexpected error occurred." };
+    return errorResponse(error);
+  }
+};
+
+export const addNewLift = async (newLift: Lift) => {
+  try {
+    const parsedLift = liftSchema.optional().parse(newLift);
+    const { data } = await axios.post(`${apiUrl}/lifts`, parsedLift);
+    const parsedData: SuccessfulInsertResponse = data.parse(
+      successfulInsertResponseSchema
+    );
+    return parsedData;
+  } catch (error) {
+    return errorResponse(error);
   }
 };

--- a/client/src/requests/lifts.ts
+++ b/client/src/requests/lifts.ts
@@ -1,0 +1,26 @@
+import axios from "axios";
+import { Lift, liftSchema } from "../types/lifts";
+import { z } from "zod";
+
+const apiUrl: string = import.meta.env.VITE_API_URL;
+
+type ErrorMessage = {
+  type: "zod error" | "API error" | "unknown error";
+  message: string;
+};
+
+export const getAllLifts = async (): Promise<Lift[] | ErrorMessage> => {
+  try {
+    const { data } = await axios.get(`${apiUrl}/lifts`);
+    liftSchema.array().parse(data);
+    return data;
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return { type: "zod error", message: error.message };
+    }
+    if (error instanceof Error) {
+      return { type: "API error", message: error.message };
+    }
+    return { type: "unknown error", message: "An unexpected error occurred." };
+  }
+};

--- a/client/src/requests/lifts.ts
+++ b/client/src/requests/lifts.ts
@@ -2,8 +2,8 @@ import axios from "axios";
 import { Lift, liftSchema } from "../types/lifts";
 import {
   ErrorMessage,
-  SuccessfulInsertResponse,
-  successfulInsertResponseSchema,
+  InsertSuccess,
+  InsertSuccessResponse,
 } from "../types/request";
 import { apiUrl, errorResponse } from "./utils";
 
@@ -21,9 +21,7 @@ export const addNewLift = async (newLift: Lift) => {
   try {
     const parsedLift = liftSchema.optional().parse(newLift);
     const { data } = await axios.post(`${apiUrl}/lifts`, parsedLift);
-    const parsedData: SuccessfulInsertResponse = data.parse(
-      successfulInsertResponseSchema
-    );
+    const parsedData: InsertSuccess = data.parse(InsertSuccessResponse);
     return parsedData;
   } catch (error) {
     return errorResponse(error);

--- a/client/src/requests/users.ts
+++ b/client/src/requests/users.ts
@@ -1,0 +1,15 @@
+import axios from "axios";
+import { apiUrl, errorResponse } from "./utils";
+import { z } from "zod";
+import { UserBase, userSchema } from "../types/users";
+
+export const getUserRecord = async (userId: string) => {
+  try {
+    z.enum(["salla", "rory"]).parse(userId);
+    const { data } = await axios.get(`${apiUrl}/user/${userId}`);
+    const parsedUser: UserBase = userSchema.parse(data);
+    return parsedUser;
+  } catch (error) {
+    return errorResponse(error);
+  }
+};

--- a/client/src/requests/utils.ts
+++ b/client/src/requests/utils.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+import { ErrorMessage } from "../types/request";
+
+export const apiUrl: string = import.meta.env.VITE_API_URL;
+
+export const errorResponse = (error: unknown): ErrorMessage => {
+  if (error instanceof z.ZodError) {
+    return { type: "zod error", message: error.message };
+  }
+  if (error instanceof Error) {
+    return { type: "API error", message: error.message };
+  }
+  return { type: "unknown error", message: "An unexpected error occurred." };
+};

--- a/client/src/types/lifts.ts
+++ b/client/src/types/lifts.ts
@@ -25,6 +25,16 @@ export interface LiftRecord {
   isMax: boolean;
 }
 
+export const LiftRecordShape = z.object({
+  id: z.string(),
+  liftId: z.string(),
+  weight: z.number().positive(),
+  date: z.string(),
+  reps: z.number().optional(),
+  userId: z.string(),
+  isMax: z.boolean(),
+});
+
 export type AllUserLifts = Record<LiftNames, LiftRecord[]>;
 
 export type LiftTargetBase = {

--- a/client/src/types/lifts.ts
+++ b/client/src/types/lifts.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { UserBase } from "./users";
 
 export type LiftNames = string;
@@ -6,8 +7,13 @@ export interface Lift {
   id: string;
   name: LiftNames;
   slug: string;
-  // hasTarget?: boolean;
 }
+
+export const liftSchema: z.ZodType<Lift> = z.object({
+  id: z.string(),
+  name: z.string(),
+  slug: z.string(),
+});
 
 export interface LiftRecord {
   id: string;

--- a/client/src/types/lifts.ts
+++ b/client/src/types/lifts.ts
@@ -39,15 +39,26 @@ export type AllUserLifts = Record<LiftNames, LiftRecord[]>;
 
 export type LiftTargetBase = {
   liftId: Lift["id"];
-  targetId: string;
-  targetWeight: number;
-  targetDate?: string;
+  id: string;
+  weight: number;
+  date?: string;
   createdAt: string;
+  status?: string;
 };
 
 export interface UserLiftTarget extends LiftTargetBase {
   userId: string;
 }
+
+export const LiftTargetShape = z.object({
+  id: z.string(),
+  user_id: z.string(),
+  lift_id: z.string(),
+  weight: z.number().positive(),
+  date: z.string(),
+  created_at: z.string(),
+  status: z.string().optional(),
+});
 
 export interface LiftTargetTracker extends LiftTargetBase {
   currentWeight: number;

--- a/client/src/types/request.ts
+++ b/client/src/types/request.ts
@@ -5,11 +5,17 @@ export type ErrorMessage = {
   message: string;
 };
 
-export const successfulInsertResponseSchema = z.object({
+export const InsertSuccessResponse = z.object({
   id: z.string(),
   message: z.string(),
 });
 
-export type SuccessfulInsertResponse = z.infer<
-  typeof successfulInsertResponseSchema
->;
+export type InsertSuccess = z.infer<typeof InsertSuccessResponse>;
+export type UpdateReponse<T> = { message: string; data: T };
+
+export const UpdateSuccessResponse = z.object({
+  message: z.string(),
+  data: z.any(),
+});
+
+export type Result<T> = Promise<T | ErrorMessage>;

--- a/client/src/types/request.ts
+++ b/client/src/types/request.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export type ErrorMessage = {
+  type: "zod error" | "API error" | "unknown error";
+  message: string;
+};
+
+export const successfulInsertResponseSchema = z.object({
+  id: z.string(),
+  message: z.string(),
+});
+
+export type SuccessfulInsertResponse = z.infer<
+  typeof successfulInsertResponseSchema
+>;

--- a/client/src/types/users.ts
+++ b/client/src/types/users.ts
@@ -1,4 +1,11 @@
+import { z } from "zod";
+
 export type UserBase = {
   id: string;
   name: "Rory" | "Salla";
 };
+
+export const userSchema = z.object({
+  id: z.enum(["rory", "salla"]),
+  name: z.enum(["Rory", "Salla"]),
+});

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -1,10 +1,11 @@
 import express, { Router } from "express";
+import { prisma } from "../database.js";
 
 const router = express.Router();
 
-// router.get("/", async (_req, res) => {
-//   // const users = await database("users").select("*");
-//   // res.status(200).json(users);
-// });
+router.get("/", async (_req, res) => {
+  const users = await prisma.users.findMany();
+  res.status(200).send(users);
+});
 
 export const userRoutes: Router = router;


### PR DESCRIPTION
# What does this PR do?

This PR connects the Frontend with the API routes, creating a number of request functions which validate query params and request bodies, and validates response types.

It is my first time using Zod on the frontend to validate what goes in and comes out of an API request, so I've done my best to keep it light and direct. I wanted to ensure I parse what is being added in the query params and request bodies and parsing the `data` of the response. This may get refined as I start to hook up all the different parts of the frontend to ensure clear error messaging, but for now it seems to read well.

I wanted to create clear request functions that return something useful like `data` or something insightful like `error.message` so I've built a type into this called `Result` which is a generic which accepts what the shape of the `data` should be and already has the `ErrorResponse` built into it. This makes sure I'm always returning something known in the frontend.   