### PR TITLE
feat: add store refresh function

### DIFF
--- a/client/src/pages/Lifts/components/LastLifts/components/LiftCard.tsx
+++ b/client/src/pages/Lifts/components/LastLifts/components/LiftCard.tsx
@@ -44,7 +44,7 @@ function LiftCard({
   const daysOfWeek = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
   const handleOpenDialog = () => !openDialog && setOpenDialog(true);
-  const { fetchUsersLifts, fetchRecordsForOneLift } = useLiftStore.getState();
+  const { refreshStore } = useLiftStore.getState();
 
   const handleDelete = async () => {
     if (!lift?.id) return;
@@ -68,8 +68,7 @@ function LiftCard({
 
     if (response.success) {
       console.log(response.data);
-      await fetchUsersLifts();
-      await fetchRecordsForOneLift(activeLift.id);
+      await refreshStore(activeLift.id);
       setOpenDialog(false);
     }
 

--- a/client/src/store/liftStore.ts
+++ b/client/src/store/liftStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
 import { LiftRecord } from "../types/lifts";
 import { getUserLiftRecords } from "../requests/liftRecords";
 
@@ -7,30 +8,48 @@ interface LiftState {
   recordsForOneLift: LiftRecord[];
   fetchUsersLifts: () => Promise<void>;
   fetchRecordsForOneLift: (liftId: string) => Promise<void>;
+  refreshStore: (liftId: string) => Promise<void>;
 }
 
-export const useLiftStore = create<LiftState>((set, get) => ({
-  usersLifts: [],
-  recordsForOneLift: [],
+export const useLiftStore = create<LiftState>()(
+  persist(
+    (set, get) => ({
+      usersLifts: [],
+      recordsForOneLift: [],
 
-  fetchUsersLifts: async () => {
-    try {
-      const userId = window.sessionStorage.getItem("userId");
-      if (userId) {
-        const response = await getUserLiftRecords(userId);
-        if (response.success) {
-          set({ usersLifts: response.data });
+      fetchUsersLifts: async () => {
+        try {
+          const userId = window.sessionStorage.getItem("userId");
+          if (userId) {
+            const response = await getUserLiftRecords(userId);
+            if (response.success) {
+              set({ usersLifts: response.data });
+            }
+          }
+        } catch (error) {
+          console.error("Error fetching lifts:", error);
         }
-      }
-    } catch (error) {
-      console.error("Error fetching lifts:", error);
+      },
+      fetchRecordsForOneLift: async (liftId: string) => {
+        const liftRecords = get().usersLifts;
+        const recordsForOneLift = liftRecords.filter(
+          (record) => record.liftId === liftId
+        );
+        set({ recordsForOneLift });
+      },
+      refreshStore: async (liftId: string) => {
+        const { fetchUsersLifts, fetchRecordsForOneLift } = get();
+        await fetchUsersLifts();
+        await fetchRecordsForOneLift(liftId);
+      },
+    }),
+    {
+      name: "lift-storage",
+      storage: createJSONStorage(() => sessionStorage),
+      partialize: (state) => ({
+        usersLifts: state.usersLifts,
+        recordsForOneLift: state.recordsForOneLift,
+      }),
     }
-  },
-  fetchRecordsForOneLift: async (liftId: string) => {
-    const liftRecords = get().usersLifts;
-    const recordsForOneLift = liftRecords.filter(
-      (record) => record.liftId === liftId
-    );
-    set({ recordsForOneLift });
-  },
-}));
+  )
+);


### PR DESCRIPTION
This pull request refactors the lift store functionality by introducing a new `refreshStore` method and adds persistence to the store using `zustand` middleware. The changes simplify the logic in `LiftCard` components and enhance state management for lift data.

### Refactoring and Simplification:

* [`client/src/pages/Lifts/components/LastLifts/components/LiftCard.tsx`](diffhunk://#diff-02cc77feba925c4ae92a26208a438375f490719abb97a110c3bc9a22ff7f5ce4L47-R47): Replaced separate calls to `fetchUsersLifts` and `fetchRecordsForOneLift` with a single call to the new `refreshStore` method in the `handleUpdate` function. This reduces redundancy and improves code clarity. [[1]](diffhunk://#diff-02cc77feba925c4ae92a26208a438375f490719abb97a110c3bc9a22ff7f5ce4L47-R47) [[2]](diffhunk://#diff-02cc77feba925c4ae92a26208a438375f490719abb97a110c3bc9a22ff7f5ce4L71-R71)

### State Management Enhancements:

* [`client/src/store/liftStore.ts`](diffhunk://#diff-dea2b6dbfb83c645845150cdcc02f068ab8ab5da18948f4608fba9124dc553b3R11-R16): Introduced a `refreshStore` method in the `LiftState` interface and implementation to consolidate fetching user lifts and records for a specific lift. [[1]](diffhunk://#diff-dea2b6dbfb83c645845150cdcc02f068ab8ab5da18948f4608fba9124dc553b3R11-R16) [[2]](diffhunk://#diff-dea2b6dbfb83c645845150cdcc02f068ab8ab5da18948f4608fba9124dc553b3L36-R55)
* [`client/src/store/liftStore.ts`](diffhunk://#diff-dea2b6dbfb83c645845150cdcc02f068ab8ab5da18948f4608fba9124dc553b3L36-R55): Added `zustand` persistence middleware to store lift data (`usersLifts` and `recordsForOneLift`) in `sessionStorage`, ensuring data persists across sessions while maintaining a lightweight footprint. [[1]](diffhunk://#diff-dea2b6dbfb83c645845150cdcc02f068ab8ab5da18948f4608fba9124dc553b3L36-R55) [[2]](diffhunk://#diff-dea2b6dbfb83c645845150cdcc02f068ab8ab5da18948f4608fba9124dc553b3R2)