### PR TITLE
feat: wire up delete record 

### DIFF
--- a/client/src/pages/Lifts/components/LastLifts/components/LiftCard.tsx
+++ b/client/src/pages/Lifts/components/LastLifts/components/LiftCard.tsx
@@ -52,6 +52,8 @@ function LiftCard({
 
     if (response.success) {
       console.log(response.data);
+      await refreshStore(activeLift.id);
+      setOpenDialog(false);
     }
     if (!response.success) {
       console.error(response.error);

--- a/client/src/requests/liftRecords.ts
+++ b/client/src/requests/liftRecords.ts
@@ -90,7 +90,7 @@ export const deleteLiftRecord = async (
   recordId: string
 ): Result<{ message: string; id: string }> => {
   try {
-    z.string().uuid().parse(recordId);
+    z.string().parse(recordId);
     const { data } = await axios.delete(
       `${apiUrl}/lift-records/record/${recordId}`
     );

--- a/client/src/store/liftStore.ts
+++ b/client/src/store/liftStore.ts
@@ -48,7 +48,6 @@ export const useLiftStore = create<LiftState>()(
       storage: createJSONStorage(() => sessionStorage),
       partialize: (state) => ({
         usersLifts: state.usersLifts,
-        recordsForOneLift: state.recordsForOneLift,
       }),
     }
   )

--- a/server/controllers/lift-records.ts
+++ b/server/controllers/lift-records.ts
@@ -150,7 +150,7 @@ export const deleteRecord: RequestHandler = async (req, res) => {
   // Deletes a record from the database
   try {
     const recordId = req.params.recordId;
-    z.string().uuid().parse(recordId);
+    z.string().parse(recordId);
     const targetedRecord = await prisma.liftRecords.findFirst({
       where: { id: recordId },
     });


### PR DESCRIPTION
This pull request introduces several updates to the lift management system, focusing on improving functionality, simplifying validation, and optimizing state management. Key changes include refreshing the store after a successful operation, removing overly strict validation, and modifying state persistence.

### Functional Improvements:
* [`client/src/pages/Lifts/components/LastLifts/components/LiftCard.tsx`](diffhunk://#diff-02cc77feba925c4ae92a26208a438375f490719abb97a110c3bc9a22ff7f5ce4R55-R56): Added a call to `refreshStore` and closed the dialog (`setOpenDialog(false)`) after a successful response to ensure the UI reflects the latest data.

### Validation Simplifications:
* `client/src/requests/liftRecords.ts` and `server/controllers/lift-records.ts`: Removed the `uuid` constraint from `z.string().uuid().parse(recordId)` to allow more flexible string validation for `recordId`. [[1]](diffhunk://#diff-08cdd9e490ce3180847bea1e05c2b0cc4bd9e7471655b2118e2baf8bb87b1f84L93-R93) [[2]](diffhunk://#diff-abd206d03a6dc3eef528e094e8542eec0daa3f6e2f1ffbd80669bde98f981e34L153-R153)

### State Management Optimization:
* [`client/src/store/liftStore.ts`](diffhunk://#diff-dea2b6dbfb83c645845150cdcc02f068ab8ab5da18948f4608fba9124dc553b3L51): Removed `recordsForOneLift` from the persisted state to reduce unnecessary storage usage.