### PR TITLE
feat: fix and improve how lifts are interacted with

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Liveft</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/client/src/pages/Home/components/AddLiftModal/AddLiftModal.tsx
+++ b/client/src/pages/Home/components/AddLiftModal/AddLiftModal.tsx
@@ -12,6 +12,7 @@ import LiftModalHeader from "../../../../ui/components/LiftModal/LiftModalHeader
 import LiftModalActions from "../../../../ui/components/LiftModal/LiftModalActions";
 import TextInput from "../../../../ui/components/TextInput";
 import { useLiftStore } from "../../../../store/liftStore";
+import dayjs from "dayjs";
 
 export interface LiftInformationState
   extends Lift,
@@ -60,7 +61,7 @@ export default function AddLiftModal({
     const newLiftToAdd: Pick<LiftRecord, "weight" | "date" | "reps" | "isMax"> =
       {
         weight: weight,
-        date: new Date().toLocaleDateString("en-GB"),
+        date: dayjs(Date.now()).toString(),
         reps: reps || undefined,
         isMax: isMax,
       };

--- a/client/src/pages/Home/components/AddLiftModal/AddLiftModal.tsx
+++ b/client/src/pages/Home/components/AddLiftModal/AddLiftModal.tsx
@@ -11,6 +11,7 @@ import LiftModalBase from "../../../../ui/components/LiftModal/LiftModalBase";
 import LiftModalHeader from "../../../../ui/components/LiftModal/LiftModalHeader";
 import LiftModalActions from "../../../../ui/components/LiftModal/LiftModalActions";
 import TextInput from "../../../../ui/components/TextInput";
+import { useLiftStore } from "../../../../store/liftStore";
 
 export interface LiftInformationState
   extends Lift,
@@ -35,6 +36,8 @@ export default function AddLiftModal({
 }) {
   const [liftInformation, setLiftInformation] =
     useState<LiftInformationState>(emptyLiftInformation);
+
+  const { fetchUsersLifts } = useLiftStore();
 
   const userId = window.sessionStorage.getItem("userId");
 
@@ -63,6 +66,7 @@ export default function AddLiftModal({
       };
 
     await addNewLiftRecord(userId, liftId, newLiftToAdd);
+    await fetchUsersLifts();
     resetAndCloseDialog();
   };
 
@@ -75,10 +79,10 @@ export default function AddLiftModal({
     <>
       <LiftModalBase open={open} handleClose={handleClose}>
         <LiftModalHeader
-          title="Add a new lift"
-          subtitle="Fill in details of your lift"
+          title='Add a new lift'
+          subtitle='Fill in details of your lift'
         >
-          <InputLabel htmlFor="lift-name" color="secondary">
+          <InputLabel htmlFor='lift-name' color='secondary'>
             Lift name
             <LiftAutocomplete
               value={liftInformation}
@@ -87,7 +91,7 @@ export default function AddLiftModal({
           </InputLabel>
           <TextInput
             value={liftInformation?.weight}
-            name="weight"
+            name='weight'
             onChange={(e) =>
               setLiftInformation({
                 ...liftInformation,
@@ -97,7 +101,7 @@ export default function AddLiftModal({
             label="Weight lifted in 'kg'"
           />
           <TextInput
-            name="reps"
+            name='reps'
             value={liftInformation?.reps || 0}
             onChange={(e) =>
               setLiftInformation({
@@ -105,7 +109,7 @@ export default function AddLiftModal({
                 reps: Number(e.target.value),
               })
             }
-            label="Number of reps"
+            label='Number of reps'
           />
         </LiftModalHeader>
         <LiftModalActions

--- a/client/src/pages/Lifts/components/LastLifts/components/LiftCard.tsx
+++ b/client/src/pages/Lifts/components/LastLifts/components/LiftCard.tsx
@@ -51,7 +51,7 @@ function LiftCard({
     const response = await deleteLiftRecord(lift?.id);
 
     if (response.success) {
-      console.log(response.data);
+      console.info("Lift deleted successfully");
       await refreshStore(activeLift.id);
       setOpenDialog(false);
     }
@@ -69,7 +69,7 @@ function LiftCard({
     });
 
     if (response.success) {
-      console.log(response.data);
+      console.info("Lift updated successfully");
       await refreshStore(activeLift.id);
       setOpenDialog(false);
     }

--- a/client/src/routes/home.tsx
+++ b/client/src/routes/home.tsx
@@ -4,6 +4,7 @@ import { useLiftStore } from "../store/liftStore";
 
 export const Route = createFileRoute("/home")({
   loader: async () => {
+    console.info("Loading the users lift data");
     const fetchUsersLifts = useLiftStore.getState().fetchUsersLifts;
     await fetchUsersLifts();
   },

--- a/client/src/routes/lift.$liftId.tsx
+++ b/client/src/routes/lift.$liftId.tsx
@@ -4,8 +4,13 @@ import { useLiftStore } from "../store/liftStore";
 
 export const Route = createFileRoute("/lift/$liftId")({
   loader: async ({ params }) => {
-    const { fetchRecordsForOneLift } = useLiftStore.getState();
-    fetchRecordsForOneLift(params.liftId);
+    console.info("Loading lift data for liftId:", params.liftId);
+    const { fetchRecordsForOneLift, usersLifts, fetchUsersLifts } =
+      useLiftStore.getState();
+    if (!usersLifts.length) {
+      await fetchUsersLifts();
+    }
+    await fetchRecordsForOneLift(params.liftId);
   },
   component: Lifts,
 });

--- a/client/src/store/liftStore.ts
+++ b/client/src/store/liftStore.ts
@@ -1,5 +1,4 @@
 import { create } from "zustand";
-import { persist, createJSONStorage } from "zustand/middleware";
 import { LiftRecord } from "../types/lifts";
 import { getUserLiftRecords } from "../requests/liftRecords";
 
@@ -11,44 +10,33 @@ interface LiftState {
   refreshStore: (liftId: string) => Promise<void>;
 }
 
-export const useLiftStore = create<LiftState>()(
-  persist(
-    (set, get) => ({
-      usersLifts: [],
-      recordsForOneLift: [],
+export const useLiftStore = create<LiftState>()((set, get) => ({
+  usersLifts: [],
+  recordsForOneLift: [],
 
-      fetchUsersLifts: async () => {
-        try {
-          const userId = window.sessionStorage.getItem("userId");
-          if (userId) {
-            const response = await getUserLiftRecords(userId);
-            if (response.success) {
-              set({ usersLifts: response.data });
-            }
-          }
-        } catch (error) {
-          console.error("Error fetching lifts:", error);
+  fetchUsersLifts: async () => {
+    try {
+      const userId = window.sessionStorage.getItem("userId");
+      if (userId) {
+        const response = await getUserLiftRecords(userId);
+        if (response.success) {
+          set({ usersLifts: response.data });
         }
-      },
-      fetchRecordsForOneLift: async (liftId: string) => {
-        const liftRecords = get().usersLifts;
-        const recordsForOneLift = liftRecords.filter(
-          (record) => record.liftId === liftId
-        );
-        set({ recordsForOneLift });
-      },
-      refreshStore: async (liftId: string) => {
-        const { fetchUsersLifts, fetchRecordsForOneLift } = get();
-        await fetchUsersLifts();
-        await fetchRecordsForOneLift(liftId);
-      },
-    }),
-    {
-      name: "lift-storage",
-      storage: createJSONStorage(() => sessionStorage),
-      partialize: (state) => ({
-        usersLifts: state.usersLifts,
-      }),
+      }
+    } catch (error) {
+      console.error("Error fetching lifts:", error);
     }
-  )
-);
+  },
+  fetchRecordsForOneLift: async (liftId: string) => {
+    const liftRecords = get().usersLifts;
+    const recordsForOneLift = liftRecords.filter(
+      (record) => record.liftId === liftId
+    );
+    set({ recordsForOneLift });
+  },
+  refreshStore: async (liftId: string) => {
+    const { fetchUsersLifts, fetchRecordsForOneLift } = get();
+    await fetchUsersLifts();
+    await fetchRecordsForOneLift(liftId);
+  },
+}));


### PR DESCRIPTION
This pull request introduces several updates to the `Liveft` application, focusing on improving functionality, code consistency, and user experience. The most significant changes include updating the title of the application, enhancing the `AddLiftModal` component, improving logging for better debugging, and simplifying the `liftStore` state management by removing persistence.

### User Interface Updates:
* Updated the application title in `index.html` from "Vite + React + TS" to "Liveft" to reflect the app's branding.
* Modified `AddLiftModal` to use single quotes for attributes and labels for consistency across the codebase. [[1]](diffhunk://#diff-34fde02addafc00622ab2d2481ca379b8fe538586104cc15a149fca0207dbeccL78-R86) [[2]](diffhunk://#diff-34fde02addafc00622ab2d2481ca379b8fe538586104cc15a149fca0207dbeccL90-R95) [[3]](diffhunk://#diff-34fde02addafc00622ab2d2481ca379b8fe538586104cc15a149fca0207dbeccL100-R113)

### Functional Enhancements:
* Integrated `dayjs` for date formatting in `AddLiftModal` since this was causing an error when handling `date` data in other parts of the app.
* Added a call to `fetchUsersLifts` after adding a new lift to refresh the user's lift data dynamically.

### Logging Improvements:
* Replaced `console.log` with `console.info` in `LiftCard` to provide clearer and more meaningful log messages for lift deletion and updates. [[1]](diffhunk://#diff-02cc77feba925c4ae92a26208a438375f490719abb97a110c3bc9a22ff7f5ce4L54-R54) [[2]](diffhunk://#diff-02cc77feba925c4ae92a26208a438375f490719abb97a110c3bc9a22ff7f5ce4L72-R72)
* Added logging messages to loaders in `home.tsx` and `lift.$liftId.tsx` for better traceability of data-fetching operations. [[1]](diffhunk://#diff-337df37a18c6115cb7905d19d3e8f6600491745a682f85c5ec6a568e5ee0f96cR7) [[2]](diffhunk://#diff-24034e892fbcb5438f09987d184c331f504be978d81780b8823cc8059b7dcb9dL7-R13)

### State Management Simplification:
* Removed `zustand` persistence middleware from `liftStore` cause I found it not so useful in the end. I'll track performance in terms of how many calls are happening to the database, but for not it seemed unecessary. [[1]](diffhunk://#diff-dea2b6dbfb83c645845150cdcc02f068ab8ab5da18948f4608fba9124dc553b3L2) [[2]](diffhunk://#diff-dea2b6dbfb83c645845150cdcc02f068ab8ab5da18948f4608fba9124dc553b3L14-R13) [[3]](diffhunk://#diff-dea2b6dbfb83c645845150cdcc02f068ab8ab5da18948f4608fba9124dc553b3L45-R42)